### PR TITLE
chore: replace legacy asset URLs with decoims.com

### DIFF
--- a/.deco/blocks/pages-App-39467.json
+++ b/.deco/blocks/pages-App-39467.json
@@ -10,7 +10,7 @@
             "__resolveType": "site/sections/Header.tsx",
             "campaignTimer": {},
             "logo": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 113,
               "height": 38
             },
@@ -55,7 +55,7 @@
             "__resolveType": "site/sections/Header.tsx",
             "campaignTimer": {},
             "logo": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 180,
               "height": 60,
               "href": "komea logo"
@@ -134,7 +134,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
+                "src": "https://decoims.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -210,7 +210,7 @@
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/539b78ab-1f32-4b3e-80b9-576e55df18cd/img-hero.png",
+                "src": "https://decoims.com/komea/539b78ab-1f32-4b3e-80b9-576e55df18cd/img-hero.png",
                 "width": 565,
                 "height": 500
               },
@@ -222,7 +222,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/b2b6a516-84bd-430e-a262-c21bbbbff9be/bg-komea.svg",
+                "src": "https://decoims.com/komea/b2b6a516-84bd-430e-a262-c21bbbbff9be/bg-komea.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -274,7 +274,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
+                "src": "https://decoims.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -287,10 +287,10 @@
               "width": "100%",
               "height": "227px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
                 "width": 40,
                 "height": 40
               }
@@ -312,7 +312,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/8e0f9620-01b1-4c5d-a459-13bea541ff21/bg-komea2.svg",
+                "src": "https://decoims.com/komea/8e0f9620-01b1-4c5d-a459-13bea541ff21/bg-komea2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -325,10 +325,10 @@
               "width": "990px",
               "height": "558px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               }
             },
             "sectionProps": {
@@ -567,14 +567,14 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
-                  "src": "https://assets.decocache.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
+                  "src": "https://decoims.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
+                  "src": "https://decoims.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
                   "width": 40,
                   "height": 40
                 },
@@ -596,16 +596,16 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
                   "mockup": true,
                   "width": "181",
                   "height": "370",
@@ -617,7 +617,7 @@
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f9ec2bef-6a39-4942-bc39-b1a7d23740d9/statistics-icon.png",
+                  "src": "https://decoims.com/komea/f9ec2bef-6a39-4942-bc39-b1a7d23740d9/statistics-icon.png",
                   "width": 40,
                   "height": 40
                 },
@@ -639,18 +639,18 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
+                  "src": "https://decoims.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
                   "width": "172",
                   "height": "352",
-                  "src": "https://assets.decocache.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
+                  "src": "https://decoims.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
                   "width": "172",
                   "height": "352",
                   "mockup": true,
@@ -675,13 +675,13 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png"
+                  "src": "https://decoims.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png"
                 },
                 "title": "<p><span style=\"color: #ffffff\">Crie produtos</span></p><p><span>conversando</span></p>",
                 "titleTextProps": {
@@ -700,15 +700,15 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 334,
                   "height": 682
                 },
                 "use": "video",
                 "video": {
                   "mockup": true,
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
                   "height": "658",
                   "width": "302"
                 }
@@ -716,7 +716,7 @@
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png"
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png"
                 },
                 "title": "<p><span>Receba insight </span></p><p><span style=\"color: #ffffff\">direto no app</span></p>",
                 "titleTextProps": {
@@ -735,12 +735,12 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 334,
                   "height": 682
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
+                  "src": "https://decoims.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
                   "height": "658",
                   "width": "302",
                   "mockup": true
@@ -768,8 +768,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
                   "width": 44,
                   "height": 44
                 },
@@ -777,8 +777,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -799,8 +799,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
                   "width": 44,
                   "height": 44
                 },
@@ -808,8 +808,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: rgb(242, 242, 242)\"> </span>Automatize <span style=\"color: rgb(242, 242, 242)\">o reengajamento</span></p>",
@@ -830,8 +830,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
                   "width": 44,
                   "height": 44
                 },
@@ -839,8 +839,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
                   "height": 280,
                   "width": 362
                 },
@@ -887,8 +887,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
                   "width": 44,
                   "height": 44
                 },
@@ -896,8 +896,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: rgb(242, 242, 242)\">Pergunte sobre os </span>dados<br>das suas vendas</p>",
@@ -918,8 +918,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
                   "width": 44,
                   "height": 44
                 },
@@ -927,8 +927,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
                 },
                 "title": {
                   "text": "<p>Automatize <span style=\"color: rgb(242, 242, 242)\">o</span><br><span style=\"color: rgb(242, 242, 242)\"> reengajamento</span></p>",
@@ -949,8 +949,8 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
                   "width": 44,
                   "height": 44
                 },
@@ -958,8 +958,8 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
                   "height": 280,
                   "width": 362
                 },
@@ -1066,7 +1066,7 @@
                 "fontSize": "16px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "container": {
@@ -1153,17 +1153,17 @@
                 "letterSpacing": "-0.3px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "container": {
               "backgroundColor": "linear-gradient(217.97deg, #D1CABD 21.92%, #D8C186 76.48%);",
               "backgroundMedia": {
                 "image": {
-                  "src": "https://assets.decocache.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
+                  "src": "https://decoims.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
                   "width": 1120,
                   "height": 418
-                  "src": "https://assets.decocache.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
+                  "src": "https://decoims.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
                   "width": 1120,
                   "height": 418
                 },
@@ -1221,7 +1221,7 @@
             "ctaPlacement": "center",
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
+                "src": "https://decoims.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
                 "width": 1120,
                 "height": 213
               },
@@ -1234,28 +1234,28 @@
             "socialMedias": [
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
+                  "src": "https://decoims.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
                   "alt": "Instagram logo"
                 },
                 "href": "https://www.instagram.com/lojaintegrada/"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
+                  "src": "https://decoims.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
                   "alt": "youtube logo"
                 },
                 "href": "https://www.youtube.com/@LojaIntegrada"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
+                  "src": "https://decoims.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
                   "alt": "tik tok logo"
                 },
                 "href": "https://www.tiktok.com/@lojaintegrada"
               }
             ],
             "ctaFloatingImage": {
-              "src": "https://assets.decocache.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
+              "src": "https://decoims.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
               "horizontalPosition": "-16px",
               "verticalPosition": "-20px"
             }
@@ -1300,7 +1300,7 @@
             "ctaPlacement": "center",
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
+                "src": "https://decoims.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
                 "width": 1120,
                 "height": 213
               },
@@ -1313,28 +1313,28 @@
             "socialMedias": [
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
+                  "src": "https://decoims.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
                   "alt": "Instagram logo"
                 },
                 "href": "https://www.instagram.com/lojaintegrada/"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
+                  "src": "https://decoims.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
                   "alt": "youtube logo"
                 },
                 "href": "https://www.youtube.com/@LojaIntegrada"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
+                  "src": "https://decoims.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
                   "alt": "tik tok logo"
                 },
                 "href": "https://www.tiktok.com/@lojaintegrada"
               }
             ],
             "ctaFloatingImage": {
-              "src": "https://assets.decocache.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
+              "src": "https://decoims.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
               "horizontalPosition": "-16px",
               "verticalPosition": "-20px"
             }

--- a/.deco/blocks/pages-App-596396.json
+++ b/.deco/blocks/pages-App-596396.json
@@ -10,7 +10,7 @@
             "__resolveType": "site/sections/Header.tsx",
             "campaignTimer": {},
             "logo": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 113,
               "height": 38,
               "href": "/app"
@@ -61,7 +61,7 @@
             "__resolveType": "site/sections/Header.tsx",
             "campaignTimer": {},
             "logo": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 180,
               "height": 60,
               "href": "/app"
@@ -145,7 +145,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
+                "src": "https://decoims.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -226,7 +226,7 @@
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/539b78ab-1f32-4b3e-80b9-576e55df18cd/img-hero.png",
+                "src": "https://decoims.com/komea/539b78ab-1f32-4b3e-80b9-576e55df18cd/img-hero.png",
                 "width": 565,
                 "height": 500
               },
@@ -238,7 +238,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/b2b6a516-84bd-430e-a262-c21bbbbff9be/bg-komea.svg",
+                "src": "https://decoims.com/komea/b2b6a516-84bd-430e-a262-c21bbbbff9be/bg-komea.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -295,7 +295,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
+                "src": "https://decoims.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -308,10 +308,10 @@
               "width": "100%",
               "height": "227px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
                 "width": 40,
                 "height": 40
               },
@@ -338,7 +338,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/8e0f9620-01b1-4c5d-a459-13bea541ff21/bg-komea2.svg",
+                "src": "https://decoims.com/komea/8e0f9620-01b1-4c5d-a459-13bea541ff21/bg-komea2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -351,10 +351,10 @@
               "width": "990px",
               "height": "558px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               },
               "gtmProps": {
                 "customType": "youtube:embbeded",
@@ -608,13 +608,13 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
+                  "src": "https://decoims.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png",
                   "width": 40,
                   "height": 40
                 },
@@ -636,12 +636,12 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
                   "mockup": true,
                   "height": "370",
                   "borderRadius": "20px",
@@ -653,7 +653,7 @@
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f9ec2bef-6a39-4942-bc39-b1a7d23740d9/statistics-icon.png",
+                  "src": "https://decoims.com/komea/f9ec2bef-6a39-4942-bc39-b1a7d23740d9/statistics-icon.png",
                   "width": 40,
                   "height": 40
                 },
@@ -675,12 +675,12 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 181,
                   "height": 370
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
+                  "src": "https://decoims.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
                   "width": "172",
                   "height": "352",
                   "mockup": true,
@@ -705,13 +705,13 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png"
+                  "src": "https://decoims.com/komea/d7146eb7-3c79-498e-b7d0-011bcb0e1535/icon-crie-produto.png"
                 },
                 "title": "<p><span style=\"color: #ffffff\">Crie produtos</span></p><p><span>conversando</span></p>",
                 "titleTextProps": {
@@ -730,14 +730,14 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 334,
                   "height": 682
                 },
                 "use": "video",
                 "video": {
                   "mockup": true,
-                  "src": "https://assets.decocache.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
+                  "src": "https://decoims.com/komea/6413d58e-cc58-466a-896d-5323f0ae8647/Chat--Criar-Produto-.mp4",
                   "height": "658",
                   "width": "302"
                 }
@@ -745,7 +745,7 @@
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png"
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png"
                 },
                 "title": "<p><span>Receba insight </span></p><p><span style=\"color: #ffffff\">direto no app</span></p>",
                 "titleTextProps": {
@@ -764,12 +764,12 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
+                  "src": "https://decoims.com/komea/e12ea5fe-437c-497e-a6fd-8baefe0dee98/iPhone-14-Pro.png",
                   "width": 334,
                   "height": 682
                 },
                 "video": {
-                  "src": "https://assets.decocache.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
+                  "src": "https://decoims.com/komea/21203775-63d2-4103-8142-7d43c2fd8b65/Receba-insight-.mp4",
                   "height": "658",
                   "width": "302",
                   "mockup": true
@@ -797,7 +797,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
                   "width": 44,
                   "height": 44
                 },
@@ -805,7 +805,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -826,7 +826,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
                   "width": 44,
                   "height": 44
                 },
@@ -834,7 +834,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: rgb(242, 242, 242)\"> </span>Automatize <span style=\"color: rgb(242, 242, 242)\">o reengajamento</span></p>",
@@ -855,7 +855,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
                   "width": 44,
                   "height": 44
                 },
@@ -863,7 +863,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
                   "height": 280,
                   "width": 362
                 },
@@ -908,7 +908,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
+                  "src": "https://decoims.com/komea/bc148d10-2a21-4895-a100-c98619ef4f03/receba-insight.png",
                   "width": 44,
                   "height": 44
                 },
@@ -916,7 +916,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
+                  "src": "https://decoims.com/komea/0272303f-fff4-4222-be66-497c28b941f8/01-sobredadosevendas.png"
                 },
                 "title": {
                   "text": "<p><span style=\"color: rgb(242, 242, 242)\">Pergunte sobre os </span>dados<br>das suas vendas</p>",
@@ -937,7 +937,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
+                  "src": "https://decoims.com/komea/81f55530-465e-4dbf-a8d5-d3c30c9b27d7/icon-automatize-reengajamento.png",
                   "width": 44,
                   "height": 44
                 },
@@ -945,7 +945,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
+                  "src": "https://decoims.com/komea/1213450c-927a-487a-8a20-da95fad55153/02-Automatize-o-reengajamento.png"
                 },
                 "title": {
                   "text": "<p>Automatize <span style=\"color: rgb(242, 242, 242)\">o</span><br><span style=\"color: rgb(242, 242, 242)\"> reengajamento</span></p>",
@@ -966,7 +966,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
+                  "src": "https://decoims.com/komea/8ba75879-9868-4ace-9252-d329c42b9baf/icon-crie-planilha.png",
                   "width": 44,
                   "height": 44
                 },
@@ -974,7 +974,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
+                  "src": "https://decoims.com/komea/c4e29ddd-923d-446a-9470-b0dd75247809/03-Crie-promocao-sem-planilha.png",
                   "height": 280,
                   "width": 362
                 },
@@ -1086,7 +1086,7 @@
                 "fontSize": "16px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "container": {
@@ -1178,14 +1178,14 @@
                 "letterSpacing": "-0.3px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "container": {
               "backgroundColor": "linear-gradient(217.97deg, #D1CABD 21.92%, #D8C186 76.48%);",
               "backgroundMedia": {
                 "image": {
-                  "src": "https://assets.decocache.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
+                  "src": "https://decoims.com/komea/00a0328e-ec60-431b-ae6c-eec57e579fe7/bg-um-time-de-agentes.png",
                   "width": 1120,
                   "height": 418
                 },
@@ -1248,7 +1248,7 @@
             "ctaPlacement": "center",
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
+                "src": "https://decoims.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
                 "width": 1120,
                 "height": 213
               },
@@ -1261,28 +1261,28 @@
             "socialMedias": [
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
+                  "src": "https://decoims.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
                   "alt": "Instagram"
                 },
                 "href": "https://www.instagram.com/lojaintegrada/"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
+                  "src": "https://decoims.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
                   "alt": "youtube"
                 },
                 "href": "https://www.youtube.com/@LojaIntegrada"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
+                  "src": "https://decoims.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
                   "alt": "tik tok"
                 },
                 "href": "https://www.tiktok.com/@lojaintegrada"
               }
             ],
             "ctaFloatingImage": {
-              "src": "https://assets.decocache.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
+              "src": "https://decoims.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
               "horizontalPosition": "-16px",
               "verticalPosition": "-20px"
             }
@@ -1332,7 +1332,7 @@
             "ctaPlacement": "center",
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
+                "src": "https://decoims.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
                 "width": 1120,
                 "height": 213
               },
@@ -1345,28 +1345,28 @@
             "socialMedias": [
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
+                  "src": "https://decoims.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
                   "alt": "Instagram"
                 },
                 "href": "https://www.instagram.com/lojaintegrada/"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
+                  "src": "https://decoims.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
                   "alt": "youtube"
                 },
                 "href": "https://www.youtube.com/@LojaIntegrada"
               },
               {
                 "logo": {
-                  "src": "https://assets.decocache.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
+                  "src": "https://decoims.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
                   "alt": "tik tok"
                 },
                 "href": "https://www.tiktok.com/@lojaintegrada"
               }
             ],
             "ctaFloatingImage": {
-              "src": "https://assets.decocache.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
+              "src": "https://decoims.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
               "horizontalPosition": "-16px",
               "verticalPosition": "-20px"
             }

--- a/.deco/blocks/pages-Home-178913.json
+++ b/.deco/blocks/pages-Home-178913.json
@@ -31,7 +31,7 @@
             },
             "hideSection": true,
             "backgroundImage": {
-              "src": "https://assets.decocache.com/komea/320929e8-94cd-4347-8003-212337cf8dff/bg-MOBILE2.svg"
+              "src": "https://decoims.com/komea/320929e8-94cd-4347-8003-212337cf8dff/bg-MOBILE2.svg"
             },
             "text": "<p style=\"text-align: center\">Pelo menos, o fim do jeito clássico<br>de vender online</p>",
             "textProps": {
@@ -40,7 +40,7 @@
               "fontWeight": "500"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 130,
               "height": 43
             },
@@ -79,7 +79,7 @@
             },
             "hideSection": true,
             "backgroundImage": {
-              "src": "https://assets.decocache.com/komea/656e43a6-3131-47a6-900b-987a8dab250c/bg2.svg"
+              "src": "https://decoims.com/komea/656e43a6-3131-47a6-900b-987a8dab250c/bg2.svg"
             },
             "text": "<p style=\"text-align: center\">Pelo menos, o fim do jeito clássico<br>de vender online</p>",
             "textProps": {
@@ -89,7 +89,7 @@
               "lineHeight": "1.2"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 226,
               "height": 76
             },
@@ -124,7 +124,7 @@
               "src": "https://www.youtube.com/embed/JVHpddoqZS0?si=LBV1XkYpqAb_Vpbc&amp;controls=0",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
                 "width": 40,
                 "height": 40
               },
@@ -132,7 +132,7 @@
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "height": "212px",
               "gtmProps": {
@@ -144,7 +144,7 @@
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -186,14 +186,14 @@
               "src": "https://www.youtube.com/embed/JVHpddoqZS0?si=LBV1XkYpqAb_Vpbc&amp;controls=0",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               },
               "width": "927px",
               "height": "546px",
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "gtmProps": {
                 "customTitle": "Conheça a Komea",
@@ -204,7 +204,7 @@
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -252,14 +252,14 @@
             "sectionBackground": {
               "backgroundColor": "#000000",
               "image": {
-                "src": "https://assets.decocache.com/komea/41223b47-85ef-4ae1-a65d-b29194c57fb0/star-mobile-2.svg"
+                "src": "https://decoims.com/komea/41223b47-85ef-4ae1-a65d-b29194c57fb0/star-mobile-2.svg"
               },
               "use": "image",
               "postition": "top"
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+                "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
                 "width": 148,
                 "height": 49
               },
@@ -374,14 +374,14 @@
             "sectionBackground": {
               "backgroundColor": "#000000",
               "image": {
-                "src": "https://assets.decocache.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
+                "src": "https://decoims.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
               },
               "use": "image",
               "postition": "top"
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+                "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
                 "width": 260,
                 "height": 87
               },

--- a/.deco/blocks/pages-Landing-681267.json
+++ b/.deco/blocks/pages-Landing-681267.json
@@ -24,7 +24,7 @@
               "src": "https://www.youtube.com/embed/pTd0Dwp73qg?si=NVAKqLSbpexsHBUo",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg",
                 "width": 60,
                 "height": 60
               },
@@ -32,14 +32,14 @@
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "height": "212px"
             },
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -80,14 +80,14 @@
               "src": "https://www.youtube.com/embed/pTd0Dwp73qg?si=NVAKqLSbpexsHBUo",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               },
               "width": "927px",
               "height": "546px",
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "gtmProps": {
                 "customSection": "lp-komea-inicio",
@@ -97,7 +97,7 @@
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -138,14 +138,14 @@
             "sectionBackground": {
               "backgroundColor": "#000000",
               "image": {
-                "src": "https://assets.decocache.com/komea/41223b47-85ef-4ae1-a65d-b29194c57fb0/star-mobile-2.svg"
+                "src": "https://decoims.com/komea/41223b47-85ef-4ae1-a65d-b29194c57fb0/star-mobile-2.svg"
               },
               "use": "image",
               "postition": "top"
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+                "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
                 "width": 390,
                 "height": 163
               },
@@ -258,14 +258,14 @@
             "sectionBackground": {
               "backgroundColor": "#000000",
               "image": {
-                "src": "https://assets.decocache.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
+                "src": "https://decoims.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
               },
               "use": "image",
               "postition": "top"
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+                "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
                 "width": 260,
                 "height": 87
               },

--- a/.deco/blocks/pages-Landing-945097.json
+++ b/.deco/blocks/pages-Landing-945097.json
@@ -22,20 +22,20 @@
               "src": "https://www.youtube.com/embed/pTd0Dwp73qg?si=NVAKqLSbpexsHBUo",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               },
               "width": "100%",
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "height": "212px"
             },
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -76,20 +76,20 @@
               "src": "https://www.youtube.com/embed/pTd0Dwp73qg?si=NVAKqLSbpexsHBUo",
               "use": "embed",
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               },
               "width": "927px",
               "height": "546px",
               "thumbnailImage": {
                 "width": 927,
                 "height": 546,
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               }
             },
             "bottomImage": {},
             "backgroundMedia": {
               "image": {
-                "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+                "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
               },
               "lcp": true,
               "color": "#000000",
@@ -112,11 +112,11 @@
         }
       },
       "bottomImage": {
-        "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg"
+        "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg"
       },
       "backgroundMedia": {
         "image": {
-          "src": "https://assets.decocache.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
+          "src": "https://decoims.com/komea/cf49cd59-7e27-4caa-8cd4-fe44f4795e98/video-section-background.svg"
         },
         "lcp": true,
         "color": "#000000",
@@ -146,14 +146,14 @@
       "sectionBackground": {
         "backgroundColor": "#000000",
         "image": {
-          "src": "https://assets.decocache.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
+          "src": "https://decoims.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
         },
         "use": "image",
         "postition": "top"
       },
       "media": {
         "image": {
-          "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+          "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
           "width": 260,
           "height": 87
         },
@@ -314,14 +314,14 @@
             "sectionBackground": {
               "backgroundColor": "#000000",
               "image": {
-                "src": "https://assets.decocache.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
+                "src": "https://decoims.com/komea/f6983b02-8aa1-4987-9675-45db863d6069/Star-8.svg"
               },
               "use": "image",
               "postition": "top"
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/071206ed-914b-43c4-9090-f394ab363493/komea-loja-integrada-logo.svg",
+                "src": "https://decoims.com/komea/071206ed-914b-43c4-9090-f394ab363493/komea-loja-integrada-logo.svg",
                 "width": 260,
                 "height": 87
               },

--- a/.deco/blocks/pages-Landing2-34557.json
+++ b/.deco/blocks/pages-Landing2-34557.json
@@ -6,7 +6,7 @@
       "__resolveType": "site/sections/Header.tsx",
       "campaignTimer": {},
       "logo": {
-        "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+        "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
         "width": 180,
         "height": 60,
         "alt": "komea logo"
@@ -66,7 +66,7 @@
             "__resolveType": "site/sections/Header.tsx",
             "campaignTimer": {},
             "logo": {
-              "src": "https://assets.decocache.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
+              "src": "https://decoims.com/komea/b352a0c5-16b9-4f6a-a952-bcae78f4cfd7/logo-komea.svg",
               "width": 180,
               "height": 60
             },
@@ -144,7 +144,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
+                "src": "https://decoims.com/komea/d87cfe74-e80f-43f9-a29e-1ff13dc6e230/yellow-circles-mobile.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -217,7 +217,7 @@
             },
             "media": {
               "image": {
-                "src": "https://assets.decocache.com/komea/ef0afe9d-7741-426d-bf9d-fcd24c625224/komea-mobile-image.svg",
+                "src": "https://decoims.com/komea/ef0afe9d-7741-426d-bf9d-fcd24c625224/komea-mobile-image.svg",
                 "width": 386,
                 "height": 545
               },
@@ -227,7 +227,7 @@
             "sectionBackground": {
               "backgroundColor": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/3c8f8be3-85da-4991-a733-c377f03d079c/yellow-circles.svg",
+                "src": "https://decoims.com/komea/3c8f8be3-85da-4991-a733-c377f03d079c/yellow-circles.svg",
                 "width": 1201,
                 "height": 773
               },
@@ -261,10 +261,10 @@
               "width": "100%",
               "height": "227px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               }
             },
             "sectionProps": {
@@ -275,7 +275,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
+                "src": "https://decoims.com/komea/e7b3a078-d7f7-4145-9aa1-ea26bacf8ff8/yellow-circles-mobile-2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -297,10 +297,10 @@
               "width": "990px",
               "height": "558px",
               "thumbnailImage": {
-                "src": "https://assets.decocache.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
+                "src": "https://decoims.com/komea/a5ababdd-fba2-4281-a3db-16c62b1b655b/video-thumbnail.svg"
               },
               "playButton": {
-                "src": "https://assets.decocache.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
+                "src": "https://decoims.com/komea/45481003-99d4-439c-adad-660c40eb43f1/play-button.svg"
               }
             },
             "sectionProps": {
@@ -310,7 +310,7 @@
             "backgroundMedia": {
               "color": "#D1CABD",
               "image": {
-                "src": "https://assets.decocache.com/komea/66b297b8-28ba-4309-b97a-1af27f99ffa6/yellow-circles-2.svg",
+                "src": "https://decoims.com/komea/66b297b8-28ba-4309-b97a-1af27f99ffa6/yellow-circles-2.svg",
                 "width": 1261,
                 "height": 777
               },
@@ -534,13 +534,13 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
                   "width": 40,
                   "height": 0
                 },
@@ -562,13 +562,13 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+                  "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
                 }
               },
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
                   "width": 40,
                   "height": 40
                 },
@@ -590,7 +590,7 @@
                   "fontSize": "14px"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+                  "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
                 },
                 "video": {},
                 "use": "image"
@@ -611,13 +611,13 @@
               "backgroundColor": "linear-gradient(180deg, #012b2e , #00363A , #00363A , #002E31 );"
             },
             "image": {
-              "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+              "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
             },
             "folds": [
               {
                 "textPosition": "Left",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg"
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg"
                 },
                 "title": "<p><span style=\"color: #ffffff\">Crie produtos</span></p><p><span>conversando</span></p>",
                 "titleTextProps": {
@@ -636,13 +636,13 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
+                  "src": "https://decoims.com/komea/019bd2bb-adae-443d-b14e-f8748ecfdf69/mobile-sticky-image.svg"
                 }
               },
               {
                 "textPosition": "Right",
                 "icon": {
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg"
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg"
                 },
                 "title": "<p><span>Receba insight </span></p><p><span style=\"color: #ffffff\">direto no app</span></p>",
                 "titleTextProps": {
@@ -661,7 +661,7 @@
                   "lineHeight": "125%"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/komea/41c9bdc3-72cf-4c69-85b5-6b347a97619a/komea-mobile-image.svg"
+                  "src": "https://decoims.com/komea/41c9bdc3-72cf-4c69-85b5-6b347a97619a/komea-mobile-image.svg"
                 },
                 "video": {},
                 "use": "image"
@@ -684,7 +684,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -692,7 +692,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
+                  "src": "https://decoims.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -713,7 +713,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/19278948-6f4c-401b-a532-de48a8aa116a/green-price-tag-icon.svg",
+                  "src": "https://decoims.com/komea/19278948-6f4c-401b-a532-de48a8aa116a/green-price-tag-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -721,7 +721,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/8eb8be48-6972-4833-9b67-983de80b3d04/komea-carousel-image-2.svg",
+                  "src": "https://decoims.com/komea/8eb8be48-6972-4833-9b67-983de80b3d04/komea-carousel-image-2.svg",
                   "height": 280,
                   "width": 362
                 },
@@ -744,7 +744,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/77a45ee0-dc76-42ce-9f12-0bdcbd923814/orange-price-tag-icon.svg",
+                  "src": "https://decoims.com/komea/77a45ee0-dc76-42ce-9f12-0bdcbd923814/orange-price-tag-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -752,7 +752,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
+                  "src": "https://decoims.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -794,7 +794,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
+                  "src": "https://decoims.com/komea/f815710b-3faf-4a7a-8d42-6d9736c1c2a9/statistics-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -802,7 +802,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
+                  "src": "https://decoims.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -823,7 +823,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/19278948-6f4c-401b-a532-de48a8aa116a/green-price-tag-icon.svg",
+                  "src": "https://decoims.com/komea/19278948-6f4c-401b-a532-de48a8aa116a/green-price-tag-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -831,7 +831,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/8eb8be48-6972-4833-9b67-983de80b3d04/komea-carousel-image-2.svg",
+                  "src": "https://decoims.com/komea/8eb8be48-6972-4833-9b67-983de80b3d04/komea-carousel-image-2.svg",
                   "height": 280,
                   "width": 362
                 },
@@ -854,7 +854,7 @@
               {
                 "icon": {
                   "placement": "Top right",
-                  "src": "https://assets.decocache.com/komea/77a45ee0-dc76-42ce-9f12-0bdcbd923814/orange-price-tag-icon.svg",
+                  "src": "https://decoims.com/komea/77a45ee0-dc76-42ce-9f12-0bdcbd923814/orange-price-tag-icon.svg",
                   "width": 44,
                   "height": 44
                 },
@@ -862,7 +862,7 @@
                 "cta": [],
                 "backgroundColor": "#1b4549",
                 "image": {
-                  "src": "https://assets.decocache.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
+                  "src": "https://decoims.com/komea/6f22e27a-640e-4002-b458-783e8909189f/komea-carousel-image-1.svg"
                 },
                 "title": {
                   "text": "<p><span style=\"color: #f2f2f2\">Pergunte sobre os </span><span>dados das suas vendas</span></p>",
@@ -955,7 +955,7 @@
                 "letterSpacing": "-0.3px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "cta": [
@@ -1042,7 +1042,7 @@
                 "letterSpacing": "-0.3px"
               },
               "bulletPointsIcon": {
-                "src": "https://assets.decocache.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
+                "src": "https://decoims.com/komea/615b1b6b-1f76-4b73-bda0-43ee870521e7/yellow-power-icon.svg"
               }
             },
             "cta": [
@@ -1110,7 +1110,7 @@
       "ctaPlacement": "center",
       "media": {
         "image": {
-          "src": "https://assets.decocache.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
+          "src": "https://decoims.com/komea/f69a3164-25fe-4b1c-9e22-bf112ec11f1c/Big-Komea-logo.svg",
           "width": 1120,
           "height": 213
         },
@@ -1123,28 +1123,28 @@
       "socialMedias": [
         {
           "logo": {
-            "src": "https://assets.decocache.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
+            "src": "https://decoims.com/komea/056017e4-dad5-400e-8585-233be41564df/instagram-green-logo.svg",
             "alt": "Instagram logo"
           },
           "href": "https://www.instagram.com/lojaintegrada/"
         },
         {
           "logo": {
-            "src": "https://assets.decocache.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
+            "src": "https://decoims.com/komea/91eab96f-c6a4-4472-8e32-47d8e707ee02/youtube-green-logo.svg",
             "alt": "youtube logo"
           },
           "href": "https://www.youtube.com/@LojaIntegrada"
         },
         {
           "logo": {
-            "src": "https://assets.decocache.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
+            "src": "https://decoims.com/komea/23a05d41-214c-404f-aa78-278d13ab1904/tiktok-green-logo.svg",
             "alt": "tik tok logo"
           },
           "href": "https://www.tiktok.com/@lojaintegrada"
         }
       ],
       "ctaFloatingImage": {
-        "src": "https://assets.decocache.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
+        "src": "https://decoims.com/komea/233398b3-ff44-47ca-9bd7-279a20c94257/bee.svg",
         "horizontalPosition": "-16px",
         "verticalPosition": "-20px"
       }

--- a/.deco/blocks/site.json
+++ b/.deco/blocks/site.json
@@ -5,9 +5,9 @@
     "jsonLDs": [],
     "noIndexing": false,
     "titleTemplate": "komea",
-    "favicon": "https://assets.decocache.com/komea/0fcebb0f-043b-49e4-a090-5808fce98e39/favicon.png",
+    "favicon": "https://decoims.com/komea/0fcebb0f-043b-49e4-a090-5808fce98e39/favicon.png",
     "descriptionTemplate": "komea",
-    "image": "https://assets.decocache.com/komea/3e2b63a6-5ff0-48bd-8543-a875f420c6e9/komea.png",
+    "image": "https://decoims.com/komea/3e2b63a6-5ff0-48bd-8543-a875f420c6e9/komea.png",
     "description": "O fim do jeito clássico de vender online"
   },
   "global": [


### PR DESCRIPTION
## Migração de assets legados

Substitui todas as referências de:
- `assets.decocache.com` → `decoims.com`
- `data.decoassets.com` → `decoims.com`

**7 arquivo(s) alterado(s):**
- `.deco/blocks/pages-Landing-681267.json`
- `.deco/blocks/pages-Home-178913.json`
- `.deco/blocks/site.json`
- `.deco/blocks/pages-Landing2-34557.json`
- `.deco/blocks/pages-App-39467.json`
- `.deco/blocks/pages-App-596396.json`
- `.deco/blocks/pages-Landing-945097.json`